### PR TITLE
Ensure legend threshold updates without manifest

### DIFF
--- a/deck_gl_polygon_dashboard_time_agnostic_fixed_v7_mvt2_PATCHED_v2.html
+++ b/deck_gl_polygon_dashboard_time_agnostic_fixed_v7_mvt2_PATCHED_v2.html
@@ -345,6 +345,8 @@ async function loadManifest(url) {
     return MANIFEST;
   } catch (e) {
     console.warn('Failed to load manifest; using fallback threshold', e);
+    const el = document.getElementById('uncertainLegendValue');
+    if (el) el.textContent = UNCERTAIN_THRESHOLD.toFixed(2);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Update manifest loader to refresh legend threshold when manifest fetch fails

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5362dc180832a925478e00aba62b1