### PR TITLE
Refresh orchard stats and details on UI updates

### DIFF
--- a/deck_gl_polygon_dashboard_time_agnostic_fixed_v7_mvt2_PATCHED_v2.html
+++ b/deck_gl_polygon_dashboard_time_agnostic_fixed_v7_mvt2_PATCHED_v2.html
@@ -997,11 +997,22 @@ function toggleTimeAgnosticMode() {
 // ============================
 // Event wiring
 // ============================
-function onUIChange() { 
+function onUIChange() {
   if (!isTimeAgnostic) {
-    updateSeasonLabels(); 
+    updateSeasonLabels();
   }
-  updateLayers(); 
+  updateLayers();
+  updateStatsFromRows();
+  if (selectedOrchardId !== null) {
+    const { seasonSort } = getFilters();
+    const arr = rowsByOrch.get(String(selectedOrchardId));
+    const row = Array.isArray(arr) ? arr.find(r => r.season_sort === seasonSort) : null;
+    if (row) {
+      showDetails(row);
+    } else {
+      showDetails({ orch_id: selectedOrchardId, hasMissingData: true });
+    }
+  }
 }
 
 function onTimeAgnosticFilterChange() {


### PR DESCRIPTION
## Summary
- Recompute statistics when sliders or checkboxes change
- Refresh orchard detail panel for selected orchard after season change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a539f6e804832abe720e307d96032f