### PR TITLE
Add per-orchard acreage to stats

### DIFF
--- a/deck_gl_polygon_dashboard_time_agnostic_fixed_v7_mvt2_PATCHED_v2.html
+++ b/deck_gl_polygon_dashboard_time_agnostic_fixed_v7_mvt2_PATCHED_v2.html
@@ -238,6 +238,7 @@ let map, overlay;                // MapLibre + deck overlay
 let csvRows = [];                // all rows from viz_table.csv
 let centroidsById = new Map();   // orch_id -> [lon, lat]
 let polygonsById = new Map();    // orch_id -> polygon coordinates
+let areaById = new Map();        // orch_id -> area in acres
 let seasons = [];                // unique season_sort ints
 let seasonKeyBySort = new Map(); // season_sort -> season string
 let rowsByOrch = new Map();      // orch_id -> [{...row}*] across seasons
@@ -375,6 +376,7 @@ async function buildRowsFromSeasons(manifest, baseUrl) {
       const isCover = roleMapped === 'cover' || roleMapped === 'active'; // support either label
       const cluster_role = isCover ? 'Cover Crops' : 'Bare Soil';
       const cluster_role_color = isCover ? '#2ca25f' : '#8B4513';
+      const area_acres = areaById.get(String(orch_id)) ?? null;
       allRows.push({
         orch_id: String(orch_id),
         season: String(year),               // label used in UI; simpler than 'YYYY_YYYY+1'
@@ -390,7 +392,8 @@ async function buildRowsFromSeasons(manifest, baseUrl) {
         npts_total: a.npts_total ?? null,
         env_z_season: a.env_z_season ?? null,
         flipped_this_season: Boolean(a.flipped_this_season),
-        confidence: Number(a.best_soft_norm ?? 0) // drive the 'Confidence' chip
+        confidence: Number(a.best_soft_norm ?? 0), // drive the 'Confidence' chip
+        area_acres
       });
       }
     } catch (e) { console.warn('Skipping year due to load error:', year, e); }
@@ -420,6 +423,17 @@ function indexCentroids(geojson) {
     }
     if (polygonCoords) {
       polygonsById.set(String(id), polygonCoords);
+      try {
+        let area = 0;
+        if (f.geometry?.type === 'Polygon') {
+          area = calculatePolygonArea(polygonCoords);
+        } else if (f.geometry?.type === 'MultiPolygon') {
+          for (const poly of polygonCoords) area += calculatePolygonArea(poly);
+        }
+        areaById.set(String(id), area);
+      } catch (err) {
+        console.warn('Area calculation failed for', id, err);
+      }
     }
   }
 }
@@ -718,7 +732,7 @@ function makeTimeSpecificLayer() {
   // Calculate acreage (excluding gray zone)
   let totalArea = 0, activeArea = 0;
   for (const d of reliableData) {
-    const area = calculatePolygonArea(d.polygon);
+    const area = Number(d.area_acres) || calculatePolygonArea(d.polygon);
     totalArea += area;
     if (d.cluster_role_mapped === 'Active') activeArea += area;
   }
@@ -1251,7 +1265,7 @@ console.log('Loaded rows count:', rows?.length ?? 0);
     console.error(err);
   }
 
-// Lightweight stats recompute based only on attribute rows + centroids (no polygon geometry needed)
+// Lightweight stats recompute based only on attribute rows + centroids/areas (no polygon geometry needed)
 function updateStatsFromRows() {
   try {
     const { seasonSort, showYoung, showMid, onlyFlip } = getFilters();
@@ -1290,13 +1304,22 @@ function updateStatsFromRows() {
 
     const activePercent = totalWithData > 0 ? (nActive / totalWithData * 100).toFixed(1) : '0';
 
+    // Acreage percentages
+    let totalAcres = 0, activeAcres = 0;
+    for (const r of reliable) {
+      const acres = Number(r.area_acres) || 0;
+      totalAcres += acres;
+      if (mapRole(r) === 'Active') activeAcres += acres;
+    }
+    const acresPercent = totalAcres > 0 ? (activeAcres / totalAcres * 100).toFixed(1) : '0';
+
     // Update existing UI fields
     document.getElementById('statActive').textContent = (nActive).toLocaleString();
     document.getElementById('statMixed').textContent  = (nGray).toLocaleString(); // Mixed slot shows gray count
     document.getElementById('statBaseline').textContent = (nBase).toLocaleString();
     document.getElementById('statFlipped').textContent = (rowsThisSeason.filter(r => r.flipped_this_season).length).toLocaleString();
     document.getElementById('statActivePercent').textContent = activePercent + '%';
-    // Acres percent requires polygon areas; we omit or leave previous value intact
+    document.getElementById('statAcresPercent').textContent = acresPercent + '%';
   } catch (e) {
     console.warn('Stats refresh skipped:', e);
   }


### PR DESCRIPTION
## Summary
- compute and store acreage per orchard when indexing polygons
- include `area_acres` in season rows and derive UI acreage percentages
- update stats and layer calculations to use stored acreage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a539fd9c04832aa32a2036ec2a0fab