### PR TITLE
fix: expose stats update function globally

### DIFF
--- a/deck_gl_polygon_dashboard_time_agnostic_fixed_v7_mvt2_PATCHED_v2.html
+++ b/deck_gl_polygon_dashboard_time_agnostic_fixed_v7_mvt2_PATCHED_v2.html
@@ -1285,6 +1285,7 @@ console.log('Loaded rows count:', rows?.length ?? 0);
   } catch (err) {
     console.error(err);
   }
+})();
 
 // Lightweight stats recompute based only on attribute rows + centroids/areas (no polygon geometry needed)
 function updateStatsFromRows() {
@@ -1346,7 +1347,7 @@ function updateStatsFromRows() {
   }
 }
 
-})();</script>
+</script>
 
 
 </body>


### PR DESCRIPTION
## Summary
- Move `updateStatsFromRows` outside boot IIFE so handlers can call it

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a5478b4e88832aafea0d3280991bb9