### PR TITLE
Fix PMTiles layer click handler for orchards

### DIFF
--- a/deck_gl_polygon_dashboard_time_agnostic_fixed_v7_mvt2_PATCHED_v2.html
+++ b/deck_gl_polygon_dashboard_time_agnostic_fixed_v7_mvt2_PATCHED_v2.html
@@ -1182,6 +1182,15 @@ function makePMTilesLayer() {
     minZoom: 6, maxZoom: 16,
     pickable: true,
     onDataLoad: (tj) => console.log('TileJSON loaded:', tj),
+    onClick: info => {
+      const f = info && info.object;
+      if (!f) return;
+      const orchId = f.properties?.orch_id ?? f.properties?.ORCH_ID ?? f.properties?.id;
+      const row = pickRow(orchId, getFilters().seasonSort) || { orch_id: orchId, hasMissingData: true };
+      selectedOrchardId = String(orchId);
+      showDetails(row);
+      updateLayers();
+    },
 
     renderSubLayers: (sub) => {
       const features = sub.data || [];
@@ -1209,15 +1218,6 @@ function makePMTilesLayer() {
           const orchId = f.properties?.orch_id ?? f.properties?.ORCH_ID ?? f.properties?.id;
           const row = pickRow(orchId, seasonSort);
           return fillFromRow(row);
-        },
-        onClick: info => {
-          const f = info && info.object;
-          if (!f) return;
-          const orchId = f.properties?.orch_id ?? f.properties?.ORCH_ID ?? f.properties?.id;
-          const row = pickRow(orchId, getFilters().seasonSort) || { orch_id: orchId, hasMissingData: true };
-          selectedOrchardId = String(orchId);
-          showDetails(row);
-          updateLayers();
         },
         updateTriggers: {
           getFillColor: [seasonSort, showYoung, showMid, onlyFlip, typeof UNCERTAIN_THRESHOLD !== 'undefined' ? UNCERTAIN_THRESHOLD : 0],


### PR DESCRIPTION
## Summary
- Handle clicks directly on the PMTiles MVTLayer so orchard selection works
- Keep GeoJson sublayer focused on rendering with updated triggers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a55b426f1c832abd35768fe11f59bc